### PR TITLE
chore(Dockerfile): Reduce image size

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,17 +1,17 @@
-FROM quay.io/deis/base:0.2.0
+FROM quay.io/deis/base:0.3.0
 
-ENV CLOUD_SDK_REPO="cloud-sdk-xenial"
-ENV GCLOUD_CREDENTIALS_FILE="clusterator.json"
-ENV GCLOUD_PROJECT_ID="deis-e2e-leasable"
-ENV NUMBER_OF_CLUSTERS=1
-ENV NUM_NODES="5"
-ENV MACHINE_TYPE="n1-standard-4"
-ENV ZONE="us-central1-a"
-ENV VERSION="1.2.6"
+ENV CLOUD_SDK_REPO="cloud-sdk-xenial" \
+	GCLOUD_CREDENTIALS_FILE="clusterator.json" \
+	GCLOUD_PROJECT_ID="deis-e2e-leasable" \
+	NUMBER_OF_CLUSTERS=1 \
+	NUM_NODES="5" \
+	MACHINE_TYPE="n1-standard-4" \
+	ZONE="us-central1-a" \
+	VERSION="1.2.6"
 
-RUN echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee /etc/apt/sources.list.d/google-cloud-sdk.list
-RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-RUN apt-get update -y && apt-get install -y google-cloud-sdk
+RUN echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee /etc/apt/sources.list.d/google-cloud-sdk.list && \
+	curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+	apt-get update -y && apt-get install -y google-cloud-sdk
 
 COPY . /
 


### PR DESCRIPTION
Image size can be reduced simply by updating `FROM` to use `quay.io/deis/base:0.3.0`.

For good measure, I've also consolidated multiple `ENV` and `RUN` directives. This reduces the number of layers, which also helps, albeit significantly in this particular case. It does, however, make the composition of this Dockerfile more consistent with others.

Net size reduction is 24 MB.
