### PR TITLE
feat(*): remove (gke) VERSION default

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Docker image that can spin up or tear down clusters in GKE.
 The `create` script will iterate the list of names supplied by the [names](rootfs/names) file. It will first check to see if that name already exists in the project. If so we skip it and move on to the next name. Otherwise, we try and create a cluster with that name. Creation of the cluster is a blocking operation. After that takes place we will set the version of the cluster to the appropriate value (this operation is not blocking).
 
 ## Deleting clusters
-The `delete` script will iterate all names and if that name appears in the project it will attempt to remove it (this operation is not blocking). 
+The `delete` script will iterate all names and if that name appears in the project it will attempt to remove it (this operation is not blocking).
 
 ## Environment Variables
 * `CLOUD_SDK_REPO`: Version of the cloud sdk to install. (default:`"cloud-sdk-xenial"`)
@@ -15,4 +15,4 @@ The `delete` script will iterate all names and if that name appears in the proje
 * `NUM_NODES`: Number of nodes to create when spinning up a new cluster. (default:`"5"`)
 * `MACHINE_TYPE`: The machine size that should be used. (default:`"n1-standard-4"`)
 * `ZONE`: The zone where the clusters should be placed. (default:`"us-central1-a"`)
-* `VERSION`: The version of kubernetes to use. (default:`"1.2.5"`)
+* `VERSION`: The version of kubernetes to use. (default: the latest GKE version)

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -7,7 +7,6 @@ ENV CLOUD_SDK_REPO="cloud-sdk-xenial" \
 	NUM_NODES="5" \
 	MACHINE_TYPE="n1-standard-4" \
 	ZONE="us-central1-a" \
-	VERSION="1.2.6"
 
 RUN echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee /etc/apt/sources.list.d/google-cloud-sdk.list && \
 	curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \

--- a/rootfs/usr/bin/create
+++ b/rootfs/usr/bin/create
@@ -13,11 +13,14 @@ while read name; do
         --num-nodes $NUM_NODES \
         --no-async &> /dev/null
 
-      echo "Upgrading Cluster to version:${VERSION}"
-      gcloud container clusters upgrade ${name} \
-        --cluster-version ${VERSION} \
-        --async \
-        --quiet &> /dev/null
+      if [ -n "${VERSION}" ]; then
+        echo "Upgrading Cluster to version:${VERSION}"
+        gcloud container clusters upgrade ${name} \
+          --cluster-version ${VERSION} \
+          --async \
+          --quiet &> /dev/null
+      fi
+
       (( successes += 1 ))
     fi
   fi


### PR DESCRIPTION
Instead, rely on value passed at runtime; else use what GKE gives us.

Also, going to bump the VERSION value in the Jenkins job to use 1.3.4... **edit**: https://github.com/deis/jenkins-jobs/pull/202
