### PR TITLE
chore(rootfs/names): remove bruno

### DIFF
--- a/rootfs/names
+++ b/rootfs/names
@@ -5,7 +5,6 @@ boizel
 boulard
 brice
 brun
-bruno
 burtin
 cattier
 heidsieck


### PR DESCRIPTION
Now that we can request clusters by name through k8s-claimer -- and this
logic uses regex to do so -- let's remove `bruno` which along with `brun`
will match the `brun` regex request.

cc @jchauncey 
