### PR TITLE
fix(rootfs/Dockerfile): remove backslash

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -6,7 +6,7 @@ ENV CLOUD_SDK_REPO="cloud-sdk-xenial" \
 	NUMBER_OF_CLUSTERS=1 \
 	NUM_NODES="5" \
 	MACHINE_TYPE="n1-standard-4" \
-	ZONE="us-central1-a" \
+	ZONE="us-central1-a"
 
 RUN echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee /etc/apt/sources.list.d/google-cloud-sdk.list && \
 	curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \


### PR DESCRIPTION
The image would not build for me with the blackslash present:

> $ make build
> docker build -t quay.io/vdice/clusterator:git-8dacbc7 rootfs
> Sending build context to Docker daemon 9.216 kB
> Error response from daemon: Syntax error - can't find = in "RUN". Must be of the form: name=value
> make: **\* [docker-build] Error 1
